### PR TITLE
Adding git url

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
-  "repository": "",
+  "repository": "https://github.com/sass-eyeglass/ember-cli-eyeglass",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This will allow npmjs.org to provide a url to the ember-cli-eyeglass repo.