### PR TITLE
Use latest release of Eyeglass.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
     "ember-try": "0.0.4",
-    "eyeglass": "^0.1.1",
+    "eyeglass": "^0.2.0",
     "grunt": "^0.4.5",
     "grunt-release": "^0.12.0"
   },


### PR DESCRIPTION
This is needed, since many sass libraries are using file naming convensions only supported in eyeglass 0.2.0.