### PR TITLE
Fixed repository field, added homepage field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
-  "repository": "https://github.com/sass-eyeglass/ember-cli-eyeglass",
+  "repository": "sass-eyeglass/ember-cli-eyeglass",
+  "homepage": "https://github.com/sass-eyeglass/ember-cli-eyeglass",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
The repository field should link to git, not http. Npm has a shortcut for Github.

The homepage field is necessary for the package's npm page to link to the Github page.