### PR TITLE
bumping broccoli-eyeglass version to 2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "broccoli"
   ],
   "dependencies": {
-    "broccoli-eyeglass": "^2.4.1",
+    "broccoli-eyeglass": "^2.4.2",
     "broccoli-funnel": "^1.0.7",
     "broccoli-merge-trees": "^1.1.4"
   },


### PR DESCRIPTION
This is needed for parallelization of sass compilation tasks.