### PR TITLE
Multi build

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,6 @@ module.exports = {
 
         // we then iterate through the config(s) and construct the output trees
         var trees = configs.map(function (config) {
-          console.log('[config]', config);
           config.annotation = "EyeglassCompiler: " + parentName;
           if (!config.sourceFiles && !config.discover) {
             config.sourceFiles = [inApp ? 'app.scss' : 'addon.scss'];

--- a/index.js
+++ b/index.js
@@ -102,45 +102,56 @@ module.exports = {
           projectConfig = addon.parent.engineConfig(host.env, projectConfig);
         }
         // setup eyeglass for this project's configuration
-        var config = projectConfig.eyeglass || {};
-        config.annotation = "EyeglassCompiler: " + parentName;
-        if (!config.sourceFiles && !config.discover) {
-          config.sourceFiles = [inApp ? 'app.scss' : 'addon.scss'];
-        }
-        config.cssDir = cssDir;
-        config.sassDir = sassDir;
-        config.assets = ["public", "app"].concat(config.assets || []);
-        config.eyeglass = config.eyeglass || {}
-        config.eyeglass.httpRoot = config.eyeglass.httpRoot ||
-                                   config.httpRoot ||
-                                   projectConfig.rootURL;
-        config.assetsHttpPrefix = config.assetsHttpPrefix || getDefaultAssetHttpPrefix(addon.parent);
+        // the config is either an Object or an Array<Object>
+        // we cast the config to an Array<Object> for consistency
+        var configs = [].concat(projectConfig.eyeglass || {});
 
-        if (config.eyeglass.modules) {
-          config.eyeglass.modules =
-            config.eyeglass.modules.concat(localEyeglassAddons(addon.parent));
-        } else {
-          config.eyeglass.modules = localEyeglassAddons(addon.parent);
-        }
+        // we then iterate through the config(s) and construct the output trees
+        var trees = configs.map(function (config) {
+          console.log('[config]', config);
+          config.annotation = "EyeglassCompiler: " + parentName;
+          if (!config.sourceFiles && !config.discover) {
+            config.sourceFiles = [inApp ? 'app.scss' : 'addon.scss'];
+          }
+          config.cssDir = cssDir;
+          config.sassDir = sassDir;
+          config.assets = ["public", "app"].concat(config.assets || []);
+          config.eyeglass = config.eyeglass || {}
+          config.eyeglass.httpRoot = config.eyeglass.httpRoot ||
+                                     config.httpRoot ||
+                                     projectConfig.rootURL;
+          config.assetsHttpPrefix = config.assetsHttpPrefix || getDefaultAssetHttpPrefix(addon.parent);
 
-        // If building an app, rename app.css to <project>.css per Ember conventions.
-        // Otherwise, we're building an addon, so rename addon.css to <name-of-addon>.css.
-        var originalGenerator = config.optionsGenerator;
-        config.optionsGenerator = function(sassFile, cssFile, sassOptions, compilationCallback) {
-          if (inApp) {
-            cssFile = cssFile.replace(/app\.css$/, addon.app.name + ".css");
+          if (config.eyeglass.modules) {
+            config.eyeglass.modules =
+              config.eyeglass.modules.concat(localEyeglassAddons(addon.parent));
           } else {
-            cssFile = cssFile.replace(/addon\.css$/, addon.parent.name + ".css");
+            config.eyeglass.modules = localEyeglassAddons(addon.parent);
           }
 
-          if (originalGenerator) {
-            originalGenerator(sassFile, cssFile, sassOptions, compilationCallback);
-          } else {
-            compilationCallback(cssFile, sassOptions);
-          }
-        };
+          // If building an app, rename app.css to <project>.css per Ember conventions.
+          // Otherwise, we're building an addon, so rename addon.css to <name-of-addon>.css.
+          var originalGenerator = config.optionsGenerator;
+          config.optionsGenerator = function(sassFile, cssFile, sassOptions, compilationCallback) {
+            if (inApp) {
+              cssFile = cssFile.replace(/app\.css$/, addon.app.name + ".css");
+            } else {
+              cssFile = cssFile.replace(/addon\.css$/, addon.parent.name + ".css");
+            }
 
-        tree = new EyeglassCompiler(tree, config);
+            if (originalGenerator) {
+              originalGenerator(sassFile, cssFile, sassOptions, compilationCallback);
+            } else {
+              compilationCallback(cssFile, sassOptions);
+            }
+          };
+
+          // pass the config and return our output tree
+          return new EyeglassCompiler(tree, config);
+        });
+
+        // merge all output trees
+        tree = merge(trees, { overwrite: true });
 
         // Ember CLI will ignore any non-CSS files returned in the tree for an
         // addon. So that non-CSS assets aren't lost, we'll store them in a


### PR DESCRIPTION
This adds support for passing multiple config objects to `ember-cli-eyeglass`.

For example, if you wanted to produce both `compressed` and `nested` output, you could do something like this...
```js
module.exports = function() {
  return {
    eyeglass: [
      {
        ...
        outputStyle: "nested"
      },
      {
        ...
        outputStyle: "compressed",
        optionsGenerator: function (sassFile, cssFile, sassOptions, compilationCallback) {
          cssFile = cssFile.replace(/\.css$/, '.min.css');
          compilationCallback(cssFile, sassOptions);
        }
      }
    ]
  };
};
```

This will result in each source `*.scss` file being compiled to both a `*.css` and `*.min.css` files.

The diff looks "complicated", but there are actually only three changes:
- l107: convert the `eyeglass` config to an `Array`
- l110, l150: iterate over this array (`.map`), returning an Array of Trees.
- l154: merge the trees back into `tree`