### PR TITLE
Avoid mutating shared project configuration.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var findHost = require("./lib/findHost");
 var funnel = require("broccoli-funnel");
 var merge = require("broccoli-merge-trees");
 var path = require("path");
+var cloneDeep = require('lodash.clonedeep');
 
 function isLazyEngine(addon) {
   if (addon.lazyLoading === true) {
@@ -112,8 +113,9 @@ module.exports = {
         if (addon.parent && addon.parent.engineConfig) {
           projectConfig = addon.parent.engineConfig(host.env, projectConfig);
         }
+
         // setup eyeglass for this project's configuration
-        var config = projectConfig.eyeglass || {};
+        var config = projectConfig.eyeglass ? cloneDeep(projectConfig.eyeglass) : {};
         config.annotation = "EyeglassCompiler: " + parentName;
         if (!config.sourceFiles && !config.discover) {
           config.sourceFiles = [inApp ? 'app.scss' : 'addon.scss'];

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "dependencies": {
     "broccoli-eyeglass": "^2.4.1 || ^3.0.0",
     "broccoli-funnel": "^1.0.7",
-    "broccoli-merge-trees": "^1.1.4"
+    "broccoli-merge-trees": "^1.1.4",
+    "lodash.clonedeep": "^4.5.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
The current implementation mutates the host project's configuration. For older versions of ember-cli the project configuration was generated every time `project.config()` was invoked, but newer versions will avoid the wasted/duplicated work and begin caching. Unfortunately, ember-cli-eyeglass relies on the fact that `project.config()` is not cached and mutates the `project.config().eyeglass` config directly.

This commit ensures that the project config is cloned before we begin mutating.